### PR TITLE
fix: double logs

### DIFF
--- a/packages/preload/src/modules/config.ts
+++ b/packages/preload/src/modules/config.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises';
 import path from 'path';
-import log from 'electron-log';
 import { produce, type WritableDraft } from 'immer';
 
 import type { Config } from '/shared/types/config';
@@ -46,7 +45,7 @@ export async function getConfig(): Promise<Readonly<Config>> {
       try {
         await writeConfig(getDefaultConfig());
       } catch (e) {
-        log.error('[Preload] Failed initializing config file', e);
+        console.error('[Preload] Failed initializing config file', e);
       }
     }
   }
@@ -68,7 +67,7 @@ export async function writeConfig(_config: Config): Promise<void> {
     // Update the in-memory config variable with the new configuration
     config = _config;
   } catch (e) {
-    log.error('[Preload] Failed writing to config file', e);
+    console.error('[Preload] Failed writing to config file', e);
     throw e;
   }
 }

--- a/packages/renderer/src/modules/file.ts
+++ b/packages/renderer/src/modules/file.ts
@@ -1,5 +1,3 @@
-import log from 'electron-log';
-
 const MAX_NAME_LENGTH = 30;
 
 export function truncateFileName(name: string) {
@@ -32,7 +30,7 @@ export async function getFileSize(src: string): Promise<number> {
       return fileSize ? parseInt(fileSize, 10) : 0;
     }
   } catch (error) {
-    log.error('[Renderer] Error retrieving file size:', error);
+    console.error('[Renderer] Error retrieving file size:', error);
   }
 
   return 0;

--- a/packages/renderer/src/modules/store/index.ts
+++ b/packages/renderer/src/modules/store/index.ts
@@ -1,4 +1,3 @@
-import log from 'electron-log';
 import { configureStore, createDraftSafeSelector } from '@reduxjs/toolkit';
 import {
   type TypedUseSelectorHook,
@@ -58,7 +57,7 @@ async function start() {
       store.dispatch(workspaceActions.getWorkspace()),
     ]);
   } catch (error: any) {
-    log.error(`[Renderer]: Failed to start up error=${error.message}`);
+    console.error(`[Renderer]: Failed to start up error=${error.message}`);
   }
 }
 


### PR DESCRIPTION
Avoid using `electron-log` on the renderer because it has an issue where it logs everything twice on the web devtools console