### PR TITLE
fix: stuck update

### DIFF
--- a/packages/main/src/modules/bin.ts
+++ b/packages/main/src/modules/bin.ts
@@ -126,7 +126,7 @@ export async function install() {
           cwd: APP_UNPACKED_PATH,
           workspace,
         });
-        await npmInstall.waitFor(/added \d+ packages/); // wait for successs message, because when the user quits the app while installing, npm exits gracefully with an exit code=0;
+        await npmInstall.waitFor(/added \d+ packages|up to date/); // wait for successs message, because when the user quits the app while installing, npm exits gracefully with an exit code=0;
 
         // save the current version to the registry
         log.info('[Install] Writing current version to the registry');

--- a/packages/main/src/modules/bin.ts
+++ b/packages/main/src/modules/bin.ts
@@ -132,7 +132,7 @@ export async function install() {
         log.info('[Install] Writing current version to the registry');
         await fs.writeFile(
           path.join(APP_UNPACKED_PATH, 'version.json'),
-          JSON.stringify({ version: import.meta.env.VITE_APP_VERSION }),
+          JSON.stringify({ version: app.getVersion() }),
         );
       } else {
         log.info('[Install] Skipping installation of node_modules because it is up to date');


### PR DESCRIPTION
This PR fixes an issue where the initial installation of the Editor gets stuck.

It's a combination of two issues:

1. The regex that waited for the npm install to finish did no account for "up to date".
2. The version stored in the registry to check if an npm install is needed was wrong (it was the package.json version which is always 0.0.0-dev instead of the app version).

The wrong version caused the Editor to always perform an npm install on start up. So the first time you install the Editor is all good, because the npm install does install packages and the regex matches. The second time you run the Editor, since the version stored was wrong, it will do an npm install again, which goes well, but it print "up to date" instead of "added XXX packages" so the regex keeps waiting forever.

This PR fixes the two issues, so no unnecesary npm installs are triggered because the version stored is now the correct one, and also if an npm install does not add new packages, the regex should still match and let the installation finish.