### PR TITLE
fix: use binaries from editor node_modules in case they are not installed in the scene

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -81,11 +81,11 @@ if (import.meta.env.PROD) {
         log.info('[AutoUpdater] Update not available');
       });
       updater.autoUpdater.on('update-downloaded', async info => {
-        log.info('[AutoUpdater] Update downloaded');
+        log.info(`[AutoUpdater] Update downloaded (v${info.version})`);
         await track('Auto Update Editor', { version: info.version });
       });
       updater.autoUpdater.on('download-progress', info => {
-        log.info(`[AutoUpdater] Download progress ${info.percent}%`);
+        log.info(`[AutoUpdater] Download progress ${info.percent.toFixed(2)}%`);
       });
       updater.autoUpdater.on('error', err => {
         log.error('[AutoUpdater] Error in auto-updater', err);

--- a/packages/main/src/modules/bin.ts
+++ b/packages/main/src/modules/bin.ts
@@ -132,7 +132,7 @@ export async function install() {
         // install dependencies using npm
         log.info('[Install] Installing node_modules...');
         const npmInstall = run('npm', 'npm', {
-          args: ['install'],
+          args: ['install', '--loglevel', 'error'],
           cwd: APP_UNPACKED_PATH,
           workspace,
         });
@@ -229,7 +229,7 @@ export function run(pkg: string, bin: string, options: RunOptions = {}): Child {
 
   const ready = future<void>();
 
-  const name = `${pkg} ${args.join(' ')}`.trim();
+  const name = `${bin} ${args.join(' ')}`.trim();
   forked.on('spawn', () => {
     log.info(
       `[UtilityProcess] Running "${name}" using bin=${binPath} with pid=${forked.pid} in ${cwd}`,

--- a/packages/main/src/modules/cli.ts
+++ b/packages/main/src/modules/cli.ts
@@ -15,13 +15,12 @@ export async function start(path: string) {
   if (previewServer) {
     await previewServer.kill();
   }
-  const installCommand = run('npm', 'npm', { args: ['install'], cwd: path });
+  const installCommand = run('npm', 'npm', { args: ['install', '--loglevel', 'error'], cwd: path });
   await installCommand.wait();
   const port = await getAvailablePort();
   previewServer = run('@dcl/sdk-commands', 'sdk-commands', {
     args: ['start', '--port', port.toString(), '--no-browser'],
     cwd: path,
-    workspace: path,
   });
   await previewServer.waitFor(/available/i);
   return port;
@@ -42,7 +41,6 @@ export async function deploy({ path, target, targetContent }: DeployOptions) {
       ...(targetContent ? ['--target-content', targetContent] : []),
     ],
     cwd: path,
-    workspace: path,
   });
 
   // App ready at


### PR DESCRIPTION
This PR removes the use of the scene path as the workspace when doing a `sdk-commands start` or a `sdk-commands deploy` because when working on scenes that do not have a `node_modules` folder (like [Goerli Plaza](https://github.com/decentraland/sdk7-goerli-plaza), because the `node_modules` is one directory above).

It also removes some warnings from the npm install logs that pollute the main logs.

Closes #57. It does not run commands with `npx` because that did not work properly on the executable version of the app. But this approach still fixes the issue.
